### PR TITLE
Add initial static homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,50 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DeadRise Marine Surveying Group</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            text-align: center;
-        }
-        header {
-            background-color: #00334d;
-            color: white;
-            padding: 1rem 0;
-        }
-        .hero {
-            position: relative;
-        }
-        .hero img {
-            width: 100%;
-            height: auto;
-        }
-        .tagline {
-            font-size: 1.2rem;
-            margin-top: 0.5rem;
-        }
-        .lighthouse {
-            margin: 2rem auto;
-            max-width: 800px;
-        }
-        .lighthouse img {
-            width: 100%;
-            height: auto;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
     <header>
         <h1>DeadRise Marine Surveying Group</h1>
         <p class="tagline">Serving the Chesapeake and Delaware Bays</p>
     </header>
-    <section class="hero">
-        <img src="images/sunset.jpg" alt="Boats at sunset on the water" />
-    </section>
-    <section class="lighthouse">
-        <h2>Sharps Island Lighthouse</h2>
-        <img src="images/sharps-island-lighthouse.jpg" alt="Sharps Island Lighthouse" />
-    </section>
+    <main>
+        <section class="hero">
+            <img src="images/sunset.jpg" alt="Sunset over boats on the Chesapeake Bay" />
+        </section>
+        <section class="lighthouse">
+            <h2>Sharps Island Lighthouse</h2>
+            <img src="images/sharps-island-lighthouse.jpg" alt="Leaning Sharps Island Lighthouse in the Chesapeake Bay" />
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 DeadRise Marine Surveying Group</p>
+    </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DeadRise Marine Surveying Group</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+        }
+        header {
+            background-color: #00334d;
+            color: white;
+            padding: 1rem 0;
+        }
+        .hero {
+            position: relative;
+        }
+        .hero img {
+            width: 100%;
+            height: auto;
+        }
+        .tagline {
+            font-size: 1.2rem;
+            margin-top: 0.5rem;
+        }
+        .lighthouse {
+            margin: 2rem auto;
+            max-width: 800px;
+        }
+        .lighthouse img {
+            width: 100%;
+            height: auto;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>DeadRise Marine Surveying Group</h1>
+        <p class="tagline">Serving the Chesapeake and Delaware Bays</p>
+    </header>
+    <section class="hero">
+        <img src="images/sunset.jpg" alt="Boats at sunset on the water" />
+    </section>
+    <section class="lighthouse">
+        <h2>Sharps Island Lighthouse</h2>
+        <img src="images/sharps-island-lighthouse.jpg" alt="Sharps Island Lighthouse" />
+    </section>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,34 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
+header {
+    background-color: #00334d;
+    color: white;
+    padding: 1rem 0;
+}
+
+.tagline {
+    font-size: 1.2rem;
+    margin-top: 0.5rem;
+}
+
+.hero img,
+.lighthouse img {
+    width: 100%;
+    height: auto;
+}
+
+.lighthouse {
+    margin: 2rem auto;
+    max-width: 800px;
+}
+
+footer {
+    background-color: #f0f0f0;
+    padding: 1rem 0;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- create simple index.html for DeadRise Marine Surveying Group
- include hero sunset image and Sharps Island Lighthouse section

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a0658faab88323942e0afa36d52dd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a static landing page for DeadRise Marine Surveying Group.
  * Added a prominent header with site title and tagline.
  * Included a hero section featuring a full-width sunset image.
  * Highlighted Sharps Island Lighthouse with supporting image and content.
  * Implemented responsive, centered layout with scalable images and constrained content width.
  * Applied an external stylesheet for a dark header and clean, accessible presentation (alt text included).
  * Delivered a lightweight, no-JavaScript page for fast loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->