### PR TITLE
Add survey booking page with navigation links

### DIFF
--- a/book.html
+++ b/book.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Contact DeadRise Marine Surveying Group with your questions." />
-    <title>Ask A Question - DeadRise Marine Surveying Group</title>
+    <meta name="description" content="Book a marine survey with DeadRise Marine Surveying Group." />
+    <title>Book A Survey - DeadRise Marine Surveying Group</title>
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -20,7 +20,7 @@
     </header>
     <main>
         <section class="form-section">
-            <h1>Ask A Question</h1>
+            <h1>Book A Survey</h1>
             <form action="#" method="post">
                 <label for="name">Name</label>
                 <input type="text" id="name" name="name" required />
@@ -28,8 +28,24 @@
                 <label for="email">Email</label>
                 <input type="email" id="email" name="email" required />
 
-                <label for="question">Question</label>
-                <textarea id="question" name="question" rows="5" required></textarea>
+                <label for="phone">Phone</label>
+                <input type="tel" id="phone" name="phone" required />
+
+                <label for="vessel">Vessel Type</label>
+                <input type="text" id="vessel" name="vessel" />
+
+                <label for="survey">Survey Type</label>
+                <select id="survey" name="survey">
+                    <option value="pre-purchase">Pre-Purchase</option>
+                    <option value="insurance">Insurance</option>
+                    <option value="damage">Damage Assessment</option>
+                </select>
+
+                <label for="date">Preferred Date</label>
+                <input type="date" id="date" name="date" />
+
+                <label for="details">Additional Details</label>
+                <textarea id="details" name="details" rows="5"></textarea>
 
                 <button type="submit" class="btn primary">Submit</button>
             </form>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <nav class="main-nav">
             <ul>
                 <li><a href="ask.html">Ask A Question</a></li>
-                <li><a href="#">Book A Survey</a></li>
+                <li><a href="book.html">Book A Survey</a></li>
                 <li><a href="#">Examples</a></li>
             </ul>
         </nav>
@@ -24,7 +24,7 @@
                 <h1>Professional Marine Inspection<br />Chesapeake and Delaware Bays</h1>
                 <p>DeadRise Marine Surveying Group provides comprehensive vessel surveys and inspections throughout the Chesapeake and Delaware Bays, giving boat owners confidence on the water.</p>
                 <div class="cta-buttons">
-                    <a href="#" class="btn primary">Get Started</a>
+                    <a href="book.html" class="btn primary">Get Started</a>
                       <a href="ask.html" class="btn secondary">Ask A Question</a>
                 </div>
                 <p class="note">Manage your vessel with confidence.</p>

--- a/index2.html
+++ b/index2.html
@@ -12,7 +12,7 @@
     <nav>
       <ul>
           <li><a href="ask.html">Ask A Question</a></li>
-        <li><a href="#book">Book A Survey</a></li>
+        <li><a href="book.html">Book A Survey</a></li>
         <li><a href="#examples">Examples</a></li>
       </ul>
     </nav>
@@ -26,7 +26,7 @@
       </h1>
       <p>Accurate, independent vessel surveys delivered with decades of local expertise. We help buyers, owners and insurers understand every detail before they set sail.</p>
       <div class="cta-buttons">
-        <a href="#book" class="btn primary">Get Started</a>
+        <a href="book.html" class="btn primary">Get Started</a>
         <a href="#projects" class="btn secondary">See Our Latest Project</a>
       </div>
       <div class="stats">


### PR DESCRIPTION
## Summary
- add Book A Survey page with form fields for contact and vessel information
- link navigation and call-to-action buttons to new booking page

## Testing
- `npm test` (fails: could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1a034e4288323b30e4567bec15a95