### PR TITLE
Remove stats bar from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,24 +34,6 @@
                 <img src="images/sunset.jpg" alt="Sunset over boats on the Chesapeake Bay" />
             </div>
         </section>
-        <section class="stats">
-            <div class="stat">
-                <span class="number">450+</span>
-                <span class="label">Surveys</span>
-            </div>
-            <div class="stat">
-                <span class="number">1.5k+</span>
-                <span class="label">Vessels Inspected</span>
-            </div>
-            <div class="stat">
-                <span class="number">850+</span>
-                <span class="label">Harbor Visits</span>
-            </div>
-            <div class="stat">
-                <span class="number">100%</span>
-                <span class="label">Satisfied Clients</span>
-            </div>
-        </section>
         <section class="services">
             <article class="service">
                 <div class="icon">⚓</div>

--- a/index2.html
+++ b/index2.html
@@ -29,24 +29,6 @@
         <a href="book.html" class="btn primary">Get Started</a>
         <a href="#projects" class="btn secondary">See Our Latest Project</a>
       </div>
-      <div class="stats">
-        <div>
-          <h2>450+</h2>
-          <p>Surveys Completed</p>
-        </div>
-        <div>
-          <h2>1.5k+</h2>
-          <p>Vessels Assessed</p>
-        </div>
-        <div>
-          <h2>850+</h2>
-          <p>Harbor Visits</p>
-        </div>
-        <div>
-          <h2>100%</h2>
-          <p>Satisfied Clients</p>
-        </div>
-      </div>
     </div>
     <div class="hero-image">
       <img src="images/sunset.jpg" alt="Surveyor inspecting a boat at sunset" />


### PR DESCRIPTION
- Remove stats section from index.html (lines 37-54)
- Remove stats div from hero section in index2.html (lines 32-49)
- Stats contained 450+ Surveys, 1.5k+ Vessels Inspected, 850+ Harbor Visits, 100% Satisfied Clients

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the hero section by removing the stats block (Surveys, Vessels Inspected, Harbor Visits, Satisfied Clients) to reduce visual clutter and improve focus on the headline, description, CTAs, and hero image across key landing pages.
  * Ensures a cleaner, more consistent above-the-fold experience without altering navigation or calls-to-action.
  * Slightly reduces page weight for marginal performance benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->